### PR TITLE
NOJIRA: refactor: Extract headers into middleware

### DIFF
--- a/middleware/headers.js
+++ b/middleware/headers.js
@@ -1,0 +1,17 @@
+const frameguard = require('frameguard');
+const nocache = require('./nocache');
+const compatibility = require('./compatibility');
+const compression = require('compression');
+
+const setup = (app, { disableCompression = false, trustProxy = true, publicPath='/public'} = {}) => {
+    app.disable('x-powered-by');
+    app.set('trust proxy', trustProxy);
+    app.use(frameguard('sameorigin'));
+    app.use(nocache.middleware({ publicPath }));
+    app.use(compatibility.middleware());
+    if (!disableCompression) app.use(compression());
+};
+
+module.exports = {
+    setup
+};

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -24,12 +24,8 @@ const middleware = {
         modelOptions: modelOptionsConfig,
         cookies: cookieOptions
     } = {}) {
-        const frameguard = require('frameguard');
-        const nocache = require('./nocache');
-        const compression = require('compression');
         const hmpoLogger = require('hmpo-logger');
         const healthcheck = require('./healthcheck');
-        const compatibility = require('./compatibility');
         const modelOptions = require('./model-options');
         const featureFlag = require('./feature-flag');
         const version = require('./version');
@@ -39,6 +35,7 @@ const middleware = {
         const hmpoComponents = require('hmpo-components');
         const public = require('./public');
         const nunjucks = require('./nunjucks');
+        const headers = require('./headers');
 
         urls.public = urls.public || '/public';
         urls.publicImages = urls.publicImages || path.posix.join(urls.public, '/images');
@@ -55,12 +52,11 @@ const middleware = {
         app.set('dev', env !== 'production');
 
         // security and headers
-        app.disable('x-powered-by');
-        app.set('trust proxy', trustProxy);
-        app.use(frameguard('sameorigin'));
-        app.use(nocache.middleware({ publicPath: urls.public }));
-        app.use(compatibility.middleware());
-        if (!disableCompression) app.use(compression());
+        headers.setup(app, {
+            disableCompression,
+            trustProxy,
+            publicPath: urls.public
+        });
 
         // version, healthcheck
         if (urls.version) app.get(urls.version, version.middleware());

--- a/test/unit/middleware/spec.headers.js
+++ b/test/unit/middleware/spec.headers.js
@@ -1,0 +1,93 @@
+const proxyquire = require('proxyquire').noPreserveCache();
+
+describe('headers middleware', () => {
+
+    let app, middleware, stubs;
+
+    beforeEach( () => {
+        app = {
+            disable: sinon.stub(),
+            set: sinon.stub(),
+            use: sinon.stub()
+        };
+
+        stubs = {
+            frameguard: sinon.stub().returns('frameguard middleware'),
+            compression: sinon.stub().returns('compression middleware'),
+            nocache: {
+                middleware: sinon.stub().returns('nocache middleware')
+            },
+            compatibility: {
+                middleware: sinon.stub().returns('compatibility middleware')
+            }
+        };
+
+        middleware = proxyquire(APP_ROOT + '/middleware/headers', {
+            'frameguard': stubs.frameguard,
+            'compression': stubs.compression,
+            './nocache': stubs.nocache,
+            './compatibility': stubs.compatibility,
+        });
+
+    });
+
+    context('by default', () => {
+
+        it('should disable the x-powered-by header', () => {
+            middleware.setup(app);
+            app.disable.should.have.been.calledWithExactly('x-powered-by');
+        });
+
+        it('should enable trust proxy by default', () => {
+            middleware.setup(app);
+            app.set.should.have.been.calledWithExactly('trust proxy', true);
+        });
+
+        it('should set trust proxy to config setting', () => {
+            middleware.setup(app, { trustProxy: ['loopback', 'localunique']});
+            app.set.should.have.been.calledWithExactly('trust proxy', ['loopback', 'localunique']);
+        });
+
+        it('should use the returned frameguard middleware', () => {
+            middleware.setup(app);
+            stubs.frameguard.should.have.been.calledOnce;
+            stubs.frameguard.should.have.been.calledWithExactly('sameorigin');
+            app.use.should.have.been.calledWithExactly('frameguard middleware');
+        });
+
+        it('should use the nocache middleware', () => {
+            middleware.setup(app);
+            stubs.nocache.middleware.should.have.been.calledWithExactly({
+                publicPath: '/public'
+            });
+            app.use.should.have.been.calledWithExactly('nocache middleware');
+        });
+
+        it('should use the nocache middleware with options', () => {
+            middleware.setup(app, { publicPath: '/static' });
+            stubs.nocache.middleware.should.have.been.calledWithExactly({
+                publicPath: '/static'
+            });
+            app.use.should.have.been.calledWithExactly('nocache middleware');
+        });
+
+        it('should use the returned compression middleware', () => {
+            middleware.setup(app);
+            stubs.compression.should.have.been.calledOnce;
+            stubs.compression.should.have.been.calledWithExactly();
+            app.use.should.have.been.calledWithExactly('compression middleware');
+        });
+
+        it('should not use the returned compression middleware if compression is disabled', () => {
+            middleware.setup(app, { disableCompression: true });
+            stubs.compression.should.not.have.been.called;
+            app.use.should.not.have.been.calledWithExactly('compression middleware');
+        });
+
+        it('should use the compatibility middleware', () => {
+            middleware.setup(app);
+            stubs.compatibility.middleware.should.have.been.calledWithExactly();
+            app.use.should.have.been.calledWithExactly('compatibility middleware');
+        });
+    });
+});


### PR DESCRIPTION
Extract the headers & security setup into separate middleware to enable easier testing, and future usage of [Helmet](https://helmetjs.github.io/)