### PR TITLE
Feat/use helmet

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Any of these options (except for `config`) can also be specified in a config fil
 >     - **`sessionIDHeader`** = `'X-SESSION-ID'`  session ID request header to pass through to models.
 >     - **`scenarioIDHeader`** = `'X-SCENARIO-ID'`  stub scenario ID request header to pass through to models.
 
+> - **`helmet`** configuration for [Helmet](https://helmetjs.github.io/), or `false` to only use frameguard and disable `x-powered-by`.  
 > - **`disableCompression`** = `false`  disable compression middleware.
 
 > - **`cookies`** configuration for cookie parsing middleware

--- a/middleware/headers.js
+++ b/middleware/headers.js
@@ -1,12 +1,25 @@
-const frameguard = require('frameguard');
+const helmetLib = require('helmet');
 const nocache = require('./nocache');
 const compatibility = require('./compatibility');
 const compression = require('compression');
 
-const setup = (app, { disableCompression = false, trustProxy = true, publicPath='/public'} = {}) => {
-    app.disable('x-powered-by');
+const setup = (app, {
+    disableCompression = false,
+    trustProxy = true,
+    publicPath='/public',
+    helmet
+} = {}) => {
+
+    // Security
+    if (helmet) {
+        app.use(helmetLib(helmet));
+    } else {
+        app.disable('x-powered-by');
+        app.use(helmetLib.frameguard('sameorigin'));
+    }
+
+    // Headers
     app.set('trust proxy', trustProxy);
-    app.use(frameguard('sameorigin'));
     app.use(nocache.middleware({ publicPath }));
     app.use(compatibility.middleware());
     if (!disableCompression) app.use(compression());

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -17,6 +17,7 @@ const middleware = {
         disableCompression = false,
         trustProxy = true,
         requestLogging = true,
+        helmet,
         views,
         locales,
         nunjucks: nunjucksOptions,
@@ -55,7 +56,8 @@ const middleware = {
         headers.setup(app, {
             disableCompression,
             trustProxy,
-            publicPath: urls.public
+            publicPath: urls.public,
+            helmet
         });
 
         // version, healthcheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -1961,6 +1961,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "helmet": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.1.0.tgz",
+      "integrity": "sha512-klsunXs8rgNSZoaUrNeuCiWUxyc+wzucnEnFejUg3/A+CaF589k9qepLZZ1Jehnzig7YbD4hEuscGXuBY3fq+g=="
+    },
     "hmpo-components": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-5.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express-session": "^1.17.3",
     "fakeredis": "^2.0.0",
     "frameguard": "^4.0.0",
+    "helmet": "5.1.0",
     "nocache": "^3.0.4",
     "on-finished": "^2.4.1",
     "redis": "4.0.x",

--- a/test/unit/middleware/spec.index.js
+++ b/test/unit/middleware/spec.index.js
@@ -184,9 +184,9 @@ describe('middleware functions', () => {
         });
 
         it('should setup headers', () => {
-            middleware.setup({ disableCompression: true, trustProxy: ['localhost'], urls: { public: '/static'} });
+            middleware.setup({ disableCompression: true, trustProxy: ['localhost'], urls: { public: '/static'}, helmet: { referrerPolicy: { policy: 'no-referrer' } } });
 
-            stubs.headers.setup.should.have.been.calledWithExactly(app, { disableCompression: true, trustProxy: ['localhost'], publicPath: '/static'});
+            stubs.headers.setup.should.have.been.calledWithExactly(app, { disableCompression: true, trustProxy: ['localhost'], publicPath: '/static', helmet: { referrerPolicy: { policy: 'no-referrer' } }});
         });
 
         it('should setup hmpoComponents', () => {


### PR DESCRIPTION
Using #17 as a base, this PR adds in support for usage of [Helmet](https://helmetjs.github.io/) if a configuration object has been passed in.

This will also allow bespoke configuration of Helmet as the configuration object is passed directly into the Helmet library.

```
app.use(
  helmet({
    contentSecurityPolicy: false,
  })
);
```