### PR TITLE
fix: unable to pass public options to public middleware

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -69,7 +69,7 @@ const middleware = {
             urls,
             publicDirs,
             publicImagesDirs,
-            ...publicOptions
+            public: publicOptions
         }));
 
         app.use(featureFlag.middleware({ featureFlags }));

--- a/test/unit/middleware/spec.index.js
+++ b/test/unit/middleware/spec.index.js
@@ -123,7 +123,8 @@ describe('middleware functions', () => {
                     public: '/public-url'
                 },
                 publicDirs: ['public'],
-                publicImagesDirs: ['assets/images']
+                publicImagesDirs: ['assets/images'],
+                public: { maxAge: 3600 }
             });
             stubs.public.middleware.should.have.been.calledWithExactly({
                 urls: {
@@ -134,7 +135,8 @@ describe('middleware functions', () => {
                     healthcheck: '/healthcheck'
                 },
                 publicDirs: ['public'],
-                publicImagesDirs: ['assets/images']
+                publicImagesDirs: ['assets/images'],
+                public: { maxAge: 3600 }
             });
             app.use.should.have.been.calledWithExactly('public middleware');
         });


### PR DESCRIPTION
Replaced spreading of publicOption variable to instead renamed to public in order for the public setup middleware to correctly destructure