### PR TITLE
DD-552 Update README and add Contribution Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contribution guidelines
+
+This is currently maintained by HMPO DCS (Digital Customer Services).
+
+## Contributing
+
+If you’ve got an idea or suggestion you can:
+
+* [Create a GitHub issue](https://github.com/HMPO/hmpo-app/issues)
+* [Open a Pull Request](https://github.com/HMPO/hmpo-app/pulls) to implement or fix a new or existing issue.
+
+## Raising bugs
+
+When reporting an issue, please include as much detail as possible to help us recreate, discuss, and resolve the problem. Here are some guidelines to follow:
+
+1. **Describe the Issue**: Provide a clear and concise description of the issue. Include any error messages, unexpected behavior, and steps to reproduce the problem.
+
+2. **Environment Details**: Specify the environment in which the issue occurred. This includes:
+
+   * Operating System (e.g., Windows 10, macOS Big Sur, Ubuntu 20.04)
+   * Browser and version (if applicable)
+   * Node.js version (if applicable)
+   * Any other relevant software versions
+
+3. **Minimal Reproducer**: To help us understand and fix the issue faster, please create a minimal reproducer repository. This should be a small, self-contained example that demonstrates the problem. Include:
+
+    * A link to the minimal reproducer repository
+    * Detailed reproduction instructions
+    * Any notes on the environment setup
+
+4. **Additional Context**: If there are any other details that might help us understand the issue better, please include them. This could be related issues, screenshots, or logs.
+
+When describing the bug it's also useful to follow the format:
+
+* what you did
+* what you expected to happen
+* what happened
+
+## Suggesting features
+
+Please raise feature requests as issues before contributing any code.
+
+This ensures they are discussed properly before any time is spent on them.
+
+## Contributing code
+
+### Indentation and whitespace
+
+Your JavaScript code should pass linting checks.
+
+We use ESLint with its rules defined by [eslint.config.js](eslint.config.js)
+Some useful docs on ESLint can be found here:
+* [ESLint - Getting Started](https://eslint.org/docs/latest/use/getting-started)
+* [ESLint - CLI Options](https://eslint.org/docs/latest/use/command-line-interface)
+* [ESLint for VS Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#:~:text=If%20you%20haven't%20installed,create%20an%20.eslintrc%20configuration%20file.)
+
+We ask that you maintain 4-space, soft-tabs only indentation.
+
+### Testing
+
+Please ensure unit tests are added or updated as appropriate for your changes.
+
+### Commit hygiene
+
+To keep our commit history clean and easy to follow, we kindly ask that you squash your commits before merging your branch into the main branch. This helps to consolidate changes and makes the history more readable.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 ## Usage
 
 ### Simple usage
-```
+
+```javascript
 const { setup } = require('hmpo-app');
 const { router } = setup();
 
@@ -13,7 +14,8 @@ router.use('/', require('./routes/example'));
 ```
 
 ### Extended usage
-```
+
+```javascript
 const {
     setup,
     featureFlag,
@@ -33,99 +35,123 @@ const {
 });
 ```
 
-See example app for more details
+See [example app](/example/) for more details
 
+## Usage Details
 
-## `setup()`
+## [`setup(options?)`](/index.js)
 
-- **`setup(options)`** Bootstrap the app. run this as early on as possible to init the logger before it is used.
+- Returned from **`require('hmpo-app')`**.
+- **`setup(options)`** Bootstraps the app. Run this as early on as possible to init the logger before it is used.
 
+### Parameters
 
-### Returned object:
+- **`options`** (`Object`) - An object containing the options for configuring the application. Defaults to `{ middlewareSetupFn: undefined }` if not provided.
 
-> - **`app`** the top-level express app
-> - **`staticRouter`** an express router before session is initialised
-> - **`router`** an express router after session is initialised
-> - **`errorRouter`** an express router before the generic error handling used to handle custom errors
+### Returns
 
-### Options object:
+- **`app`** - the top-level express app.
+- **`staticRouter`** - an express router before session is initialised.
+- **`router`** - an express router after session is initialised.
+- **`errorRouter`** - an express router before the generic error handling used to handle custom errors.
+
+### More info on the `options` Object
 
 Any of these options (except for `config`) can also be specified in a config file. The options passed to `setup()` override the options loaded from config files.
 
-> - **`config`** if `false` no config will be loaded
->     - **`APP_ROOT`**  override app root directory detection
->     - **`files`** = `'config/default(.json|.yaml|.yml)'`  array of config files to try to load. Missing files will fail silently.
->     - **`envVarName`** = `'HMPO_CONFIG'`  environment variable to parse to override config values.
->     - **`commandLineSwitch`** = `'-c'`  command line switch to load additional config files.
->     - **`merge`** = `true`  merge new config with config from previous calls to setup.
+**`config`** - if `false` no config will be loaded.
 
-> - **`env`** = `NODE_ENV` environment variable or `'development'`  environment.
+- **`APP_ROOT`** - Override app root directory detection
+- **`files`** = `'config/default(.json|.yaml|.yml)'` - Array of config files to try to load. Missing files will fail silently.
+- **`envVarName`** = `'HMPO_CONFIG'` - Environment variable to parse to override config values.
+- **`commandLineSwitch`** = `'-c'` - Command line switch to load additional config files.
+- **`merge`** = `true` - Merge new config with config from previous calls to setup.
 
-> - **`port`** = `3000`  port to bind to. If `false` the app will not listen to a port.
-> - **`host`** = `'0.0.0.0'`  host to bind to.
+**`env`** = `NODE_ENV` - Environment variable or `'development'`  environment.
 
-> - **`logs`**  see *`hmpo-logger`* options passed to logger. See *`hmpo-logger`* for defaults. If `false` no logger is initialised.
-> - **`requestLogging`** = `true`  enable request logging (excluding public static files).
+**`port`** = `3000` - Port to bind to. If `false` the app will not listen to a port.
+**`host`** = `'0.0.0.0'` - Host to bind to.
 
-> - **`redis`** if `false` redis is not initialised
->     - **`connectionString`** connection url used for connecting to a redis instance
->     - **`host`**  host name for connecting to a redis instance
->     - **`port`** = `6379`  port for connection to a redis instance
->     - **`...otherOptions`** any other options are passed to *`redis`*
->     - If neither `connectionString` or `host` and `port` are specified an in-memory redis is used
+**`logs`** - See [hmpo-logger](https://github.com/HMPO/hmpo-logger/blob/master/lib/manager.js#L24) for options passed to logger. See [hmpo-logger](https://github.com/HMPO/hmpo-logger) for defaults. If `false` no logger is initialised.
 
-> - **`errors`** if `false` no error handler is set
->     - **`startUrl`** = `'/'`  url to redirect to if a deep page is accessed as a new browser. Can be a `function(req, res)`.
->     - **`pageNotFoundView`** = `'errors/page-not-found'`  view to render for page not found.
->     - **`sessionEndedView`** = `'errors/session-ended'`  view to render if session is not found/expired.
->     - **`defaultErrorView`** = `'errors/error'`  view to render for other errors.
+**`requestLogging`** = `true` - Enable request logging (excluding public static files).
 
-> - `urls`
->     - **`public`** = `'/public'`  base URL for public static assets.
->     - **`publicImages`** = `'/public/images'`  base URL for public sttic images.
->     - **`version`** = `'/version'`  base URL for version endpoint, or `false` to disable.
->     - **`healthcheck`** = `'/healthcheck'`  base URL for healthcheck endpoint, or `false` to disable.
+**`redis`** - If `false` redis is not initialised.
 
-> - **`publicDirs`** = `['public']`  array of paths to mount on the public route, relative to `APP_ROOT`.
-> - **`publicImagesDirs`** = `['assets/images']`  array of paths to mount on the public images route, relative to `APP_ROOT`.
-> - **`publicOptions`** = `{maxAge: 86400000}`  options passed to the express static middleware.
+- **`connectionString`** - Connection url used for connecting to a redis instance.
+- **`host`** - Host name for connecting to a redis instance.
+- **`port`** = `6379` - Port for connection to a redis instance.
+- **`...otherOptions`** - Any other options are passed to *`redis`*.
+- If neither `connectionString` or `host` and `port` are specified, an in-memory redis is used.
 
-> - **`views`** = `'views'`  array of view directories relative to `APP_ROOT`.
-> - **`nunjucks`** options passed to *`nunjucks`* templatinng contructor, or `false` to disable
->     - **`dev`** = `env==='development'` run *`nunjucks`* in developer mode for more verbose errors.
->     - **`noCache`** = `env==='development'`  don't cache compiled template files.
->     - **`watch`** = `env==='development'`  watch for changes to template files.
->     - **`...otherOptions`** any other options are passed to *`nunjucks.configure`*
+**`errors`** - If `false` no error handler is set
 
-> - **`locales`** = `'.'`  array of locales base directories (containing a `'locales'` directory) relative to `APP_ROOT`.
-> - **`translation`** options passed to *`hmpo-i18n`* translation library, or `false` to disable
->     - **`noCache`** = `env==='development'`  don't cache templated localisation strings.
->     - **`watch`** = `env==='development'`  watch for changes to localisation files.
->     - **`allowedLangs`** = `['en','cy']`  array of allowed languages.
->     - **`fallbackLang`** = `['en']`  array of languages to use if translation not found is current language.
->     - **`cookie`** = `{name: 'lang'}`  cookie settings to use to store current language.
->     - **`query`** = `'lang'`  query parameter to use to change language, or `false` to disable.
->     - **`...otherOptions`** any other options are passed to *`hmpo-i18n`*
+- **`startUrl`** = `'/'` - Url to redirect to if a deep page is accessed as a new browser. Can be a `function(req, res)`.
+- **`pageNotFoundView`** = `'errors/page-not-found'` - View to render for page not found.
+- **`sessionEndedView`** = `'errors/session-ended'` - View to render if session is not found/expired.
+- **`defaultErrorView`** = `'errors/error'` - View to render for other errors.
 
-> - **`modelOptions`** configuration for model options helper to be used with *`hmpo-model`*
->     - **`sessionIDHeader`** = `'X-SESSION-ID'`  session ID request header to pass through to models.
->     - **`scenarioIDHeader`** = `'X-SCENARIO-ID'`  stub scenario ID request header to pass through to models.
+**`urls`**
 
-> - **`helmet`** configuration for [Helmet](https://helmetjs.github.io/), or `false` to only use frameguard and disable `x-powered-by`.  
-> - **`disableCompression`** = `false`  disable compression middleware.
+- **`public`** = `'/public'` - Base URL for public static assets.
+- **`publicImages`** = `'/public/images'` - Base URL for public sttic images.
+- **`version`** = `'/version'` - Base URL for version endpoint, or `false` to disable.
+- **`healthcheck`** = `'/healthcheck'` - Base URL for healthcheck endpoint, or `false` to disable.
 
-> - **`cookies`** configuration for cookie parsing middleware
+**`publicDirs`** = `['public']` - Array of paths to mount on the public route, relative to `APP_ROOT`.
+**`publicImagesDirs`** = `['assets/images']` - Array of paths to mount on the public images route, relative to `APP_ROOT`.
+**`publicOptions`** = `{maxAge: 86400000}` - Options passed to the express static middleware.
 
-## `featureFlag`
+**`views`** = `'views'` - Array of view directories relative to `APP_ROOT`.
 
-- **`getFlags(req)`** return all session and config feature flags
-- **`isEnabled(flag, req)`** check if a feature flag is enabled in session or config
-- **`isDisabled(flag, req)`** check if a feature flag is disabled in session or config
-- **`redirectIfEnabled(flag, url)`** middleware to redirect if a flag is enabled
-- **`redirectIfDisabled(flag, url)`** middleware to redirect if a flag is disabled
-- **`routeIf(flag, handlerIf, handlerElse)`** middleware to run different handler depending on status of a feature flag
+**`nunjucks`** - Options passed to *`nunjucks`* templating contructor, or `false` to disable
 
-```
+- **`dev`** = `env==='development'` - Run *`nunjucks`* in developer mode for more verbose errors.
+- **`noCache`** = `env==='development'` - Don't cache compiled template files.
+- **`watch`** = `env==='development'` - Watch for changes to template files.
+- **`...otherOptions`** - Any other options are passed to *`nunjucks.configure`*
+
+**`locales`** = `'.'` - Array of locales base directories (containing a `'locales'` directory) relative to `APP_ROOT`.
+
+**`translation`** - Options passed to [hmpo-i18n](https://github.com/HMPO/hmpo-i18n) translation library, or `false` to disable.
+
+- **`noCache`** = `env==='development'` - Don't cache templated localisation strings.
+- **`watch`** = `env==='development'` - Watch for changes to localisation files.
+- **`allowedLangs`** = `['en','cy']` - Array of allowed languages.
+- **`fallbackLang`** = `['en']` - Array of languages to use if translation not found is current language.
+- **`cookie`** = `{name: 'lang'}` - Cookie settings to use to store current language.
+- **`query`** = `'lang'` - Query parameter to use to change language, or `false` to disable.
+- **`...otherOptions`** - Any other options are passed to [hmpo-i18n](https://github.com/HMPO/hmpo-i18n).
+
+**`modelOptions`** - Configuration for model options helper to be used with [hmpo-model](https://github.com/HMPO/hmpo-model).
+
+- **`sessionIDHeader`** = `'X-SESSION-ID'` - Session ID request header to pass through to models.
+- **`scenarioIDHeader`** = `'X-SCENARIO-ID'` - Stub scenario ID request header to pass through to models.
+
+**`helmet`** - Configuration for [Helmet](https://helmetjs.github.io/), or `false` to only use frameguard and disable `x-powered-by`.  
+**`disableCompression`** = `false` - disable compression middleware.
+
+**`cookies`** - Configuration for cookie parsing middleware.
+
+## [`featureFlag`](/middleware/feature-flag.js)
+
+Middleware returned from `require('hmpo-app')`.
+
+**`getFlags(req)`** - Return all session and config feature flags.
+
+**`isEnabled(flag, req)`** - Check if a feature flag is enabled in session or config.
+
+**`isDisabled(flag, req)`** - Check if a feature flag is disabled in session or config.
+
+**`redirectIfEnabled(flag, url)`** - Middleware to redirect if a flag is enabled.
+
+**`redirectIfDisabled(flag, url)`** - Middleware to redirect if a flag is disabled.
+
+**`routeIf(flag, handlerIf, handlerElse)`** - Middleware to run different handler depending on status of a feature flag.
+
+### Example Usage
+
+```javascript
 const { featureFlag } = require('hmpo-app');
 
 const enabledMiddleware = (req, res, next) => res.send('flag enabled');
@@ -134,19 +160,65 @@ const disabledMiddleware = (req, res, next) => res.send('flag disabled');
 router.use(featureFlag.routeIf('flagname', enabledMiddleware, disabledMiddleware));
 ```
 
-## `config()`
+## [`config`](/lib/config.js)
 
-- **`config(path, defaultIfUndefined)`** get a value from loaded config by dot separated path, or a default if not found or undefined. Id any part of the path is not found, the default will be returned.
+### TODO - Talk About...
 
-```
+- defaultFiles export
+- setup export (exported method)
+- get export (exported method)
+- How Object.assign() in config.js allows for config() or config.get(). They behave the same. config.setup(), config.defaultFiles are also made available.
+
+A config helper returned from `require('hmpo-app')`.
+
+### Returns
+
+**`defaultFiles`** - An array of default config files: `[
+    'config/default.json',
+    'config/default.yaml',
+    'config/default.yml'
+];`
+
+**`setup(configOptions?)`** - A function for config setup that takes an options Object containing possible params:
+
+- `{
+    APP_ROOT,
+    seed,
+    files = defaultFiles,
+    envVarName = 'HMPO_CONFIG',
+    commandLineSwitch = '-c',
+    merge = true,
+    _commandLineArgs = process.argv,
+    _environmentVariables = process.env
+}`
+- Defaults to empty Object if no options provided.
+
+**`get(path, defaultIfUndefined)`** - Get a value from loaded config by dot separated path, or a default if not found or undefined. If any part of the path is not found, the default will be returned.
+
+### Example Usage
+
+```javascript
 const { config } = require('hmpo-app');
+
+let defaultFiles = config.defaultFiles;
+
+// Setup config
+if (options.config !== false) config.setup(options.config);
+
 const value = config.get('config.path.string', 'default value');
 ```
-## `logger()`
 
-- **`logger(name)`** get a new logger with an optional name
+## `logger`
 
-```
+### TODO - Talk About...
+
+- setup export (exported method)
+- get export (exported method)
+- How Object.assign() in logger.js allows for logger() or logger.get(). They behave the same. logger.setup() is also made available.
+
+**`logger(name)`** get a new logger with an optional name
+
+```javascript
 const { logger } = require('hmpo-app');
 
 const log = logger(':name');
@@ -157,11 +229,17 @@ log.info('log message', { req, err, other: 'metedata' });
 logger().info('log message', { req, err, other: 'metedata' });
 ```
 
-## `redisClient()`
+## `redisClient`
 
-- **`redisClient()`** return redis client
+### TODO - Talk About...
 
-```
+- setup export (exported method)
+- getClient export (exported method)
+- How Object.assign() in redis-client.js allows for redisClient() or redisClient.getClient(). They behave the same. redisClient.setup(), redisClient.client, and redisClient.close() are also made available.
+
+**`redisClient()`** return redis client
+
+```javascript
 const { redisClient } = require('hmpo-app');
 redisClient().set('key', 'value');
 ```

--- a/README.md
+++ b/README.md
@@ -213,13 +213,15 @@ const value = config('config.path.string', 'default value');
 const value = config.get('config.path.string', 'default value');
 ```
 
-## `logger`
+## [`logger`](/lib/logger.js)
 
 ### Returns
 
 **`setup(options?)`** - Setup the logger by passing an options `Object`. If no options are supplied it will default to checking `config.get('logs', {})`. This passes the provided options directly to `hmpoLogger.config()`.
 
 **`get(name?, level?)` / `logger(name?, level?)`** - Get a new logger with an optional name (defaults to `:hmpo-app`) and an optional level (defaults to `1`).
+
+### Example Usage
 
 ```javascript
 const { logger } = require('hmpo-app');
@@ -251,13 +253,7 @@ const myLogger1 = logger('logger1');
 const myLogger2 = logger.get('logger2');
 ```
 
-## `redisClient`
-
-### TODO - Talk About...
-
-- setup export (exported method)
-- getClient export (exported method)
-- How Object.assign() in redis-client.js allows for redisClient() or redisClient.getClient(). They behave the same. redisClient.setup(), redisClient.client, and redisClient.close() are also made available.
+## [`redisClient`](/lib/redis-client.js)
 
 ### Returns
 
@@ -275,6 +271,8 @@ const myLogger2 = logger.get('logger2');
 **`close(callback)`** - Quits a redisClient if it exists / is connected, then sets `redisClient.client = null`. Finally, fires the provided callback function.
 
 Due to the way [redis-client.js](/lib/redis-client.js) uses `Object.assign()`, you can use `redisClient()` and `redisClient.getClient()` interchangeably - depending on which you find better for readability.
+
+### Example Usage
 
 ```javascript
 const { redisClient } = require('hmpo-app');
@@ -302,3 +300,9 @@ redisClient.close(() => {
     console.log('Redis connection closed');
 });
 ```
+
+## Further Examples
+
+- The [example app](/example/).
+- The [hmpo-logger](https://github.com/HMPO/hmpo-logger/blob/5c69e2df6e7c8db6f4642efae5d7fb283e0c7aad/README.md?plain=1#L20) library.
+- The [hmpo-components](https://github.com/HMPO/hmpo-components/blob/3f7c5c97be49c4067877f6d2056b6369909bef17/README.md?plain=1#L24) library.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,43 @@ const logger = require('./lib/logger');
 const middleware = require('./middleware');
 const redisClient = require('./lib/redis-client');
 
+/**
+ * Initializes and sets up the core components of hmpo-app.
+ * This function configures logging, Redis, middleware, error handling, session management, and HTTP server settings.
+ *
+ * The setup process can be customized using the provided `options` object. The function will initialize the components based on the options provided, or default to values from the `config` module.
+ *
+ * @param {Object} [options={middlewareSetupFn: undefined}] - Configuration options to customize the setup process.
+ * @param {Object} [options.config] - Optional configuration for the `config.setup()` method. Set to `false` to skip configuration setup.
+ * @param {Object} [options.logs] - Optional configuration for logging. Merged with the default config fetched by `config.get('logs')`. Set to `false` to skip log setup.
+ * @param {Object} [options.redis] - Optional configuration for the Redis client. Merged with the default config fetched by `config.get('redis')`. Set to `false` to skip Redis setup.
+ * @param {Function} [options.middlewareSetupFn] - Optional function that can be used to further customize the middleware setup. This function receives the `app` instance.
+ * @param {Object} [options.session] - Optional configuration for session management. Merged with the default config fetched by `config.get('session')`. Set to `false` to skip session setup.
+ * @param {Object} [options.errors] - Optional configuration for error handling. Merged with the default config fetched by `config.get('errors')`. Set to `false` to skip error handler setup.
+ * @param {Object} [options.port] - Port to run the HTTP server on. Defaults to the value in the config file, or the value passed as `options.host`.
+ * @param {Object} [options.host] - Hostname or IP address for the server. Defaults to the value in the config file.
+ *
+ * @returns {Object} Returns an object containing the Express app and routers:
+ * - `app`: The main Express application instance.
+ * - `staticRouter`: The Express router for serving static content.
+ * - `router`: The main Express router for handling routes.
+ * - `errorRouter`: The Express router for handling errors.
+ *
+ * @example
+ * // Set up the app with default settings and custom logging options
+ * const { app, staticRouter, router, errorRouter } = setup({
+ *   logs: { level: 'debug' }
+ * });
+ *
+ * @example
+ * // Skip Redis and error handling setup, but still initialize middleware and session
+ * const { app } = setup({
+ *   redis: false,
+ *   errors: false,
+ *   session: { secret: 'my-secret' }
+ * });
+ */
+
 const setup = (options = {
     middlewareSetupFn: undefined
 }) => {

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,6 +6,56 @@ const defaultFiles = [
     'config/default.yaml',
     'config/default.yml'
 ];
+
+/**
+ * Loads and merges config data from various sources including:
+ * - a provided seed object,
+ * - default or custom config files,
+ * - environment variables,
+ * - command-line arguments.
+ *
+ * The final configuration is stored globally in `global.GLOBAL_CONFIG`.
+ * If a `timezone` is defined in the config, it sets `process.env.TZ`.
+ *
+ * @param {Object} [options={}] - Configuration options.
+ * @param {string} [options.APP_ROOT] - The root directory for resolving relative config file paths.
+ * @param {Object} [options.seed] - A pre-existing config object to use as the initial seed.
+ * @param {string[]} [options.files] - An array of config file paths to load and merge.
+ * @param {string} [options.envVarName='HMPO_CONFIG'] - Environment variable name containing config as a JSON/YAML string.
+ * @param {string} [options.commandLineSwitch='-c'] - CLI switch used to pass a config file path.
+ * @param {boolean} [options.merge=true] - Whether to merge with an existing global config.
+ * @param {string[]} [options._commandLineArgs=process.argv] - Override the default CLI args (for testing).
+ * @param {Object} [options._environmentVariables=process.env] - Override environment variables (for testing).
+ *
+ * @returns {void}
+ *
+ * * @example
+ * // Basic usage with default config files
+ * setup();
+ *
+ * @example
+ * // Using a specific config file and disabling env var/config file merging
+ * setup({
+ *   files: ['config/custom.json'],
+ *   merge: false
+ * });
+ *
+ * @example
+ * // Using a seed object instead of files/env/CLI
+ * setup({
+ *   seed: {
+ *     appName: 'my-app',
+ *     port: 3000
+ *   }
+ * });
+ *
+ * @example
+ * // Custom environment and CLI args (for testing)
+ * setup({
+ *   _environmentVariables: { HMPO_CONFIG: '{"debug":true}' },
+ *   _commandLineArgs: ['node', 'app.js', '-c', 'config/test.json']
+ * });
+ */
 const setup = ({
     APP_ROOT,
     seed,
@@ -63,6 +113,29 @@ const setup = ({
 
     global.GLOBAL_CONFIG = configData;
 };
+
+/**
+ * Retrieves a value from the global config object using a dot-notation path.
+ *
+ * Throws an error if the config has not been loaded (i.e. `global.GLOBAL_CONFIG` is undefined).
+ *
+ * If no `path` is provided, the entire config object is returned.
+ *
+ * @param {string} [path] - A dot-separated string representing the path to the config value (e.g. `"server.port"`).
+ * @param {*} [defaultIfUndefined] - A fallback value to return if the specified path is not found in the config.
+ *
+ * @returns {*} The value at the specified path, the default value if not found, or the full config if no path is provided.
+ *
+ * @throws {Error} If the config has not been loaded yet via `setup()`.
+ *
+ * @example
+ * // Assuming global.GLOBAL_CONFIG = { server: { port: 3000 }, env: 'production' }
+ *
+ * get('server.port'); // returns 3000
+ * get('env');         // returns 'production'
+ * get('missing.key', 'defaultVal'); // returns 'defaultVal'
+ * get();              // returns the entire config object
+ */
 
 const get = (path, defaultIfUndefined) => {
     if (!global.GLOBAL_CONFIG) throw new Error('Config not loaded');

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,7 +1,53 @@
 const hmpoLogger = require('hmpo-logger');
 const config = require('./config');
 
+/**
+ * Sets up the application logger using the provided options or falls back to config-defined log settings.
+ *
+ * This function delegates to `hmpoLogger.config()` to initialize logging behavior,
+ * including log levels, output format, destinations, etc.
+ *
+ * @param {Object} [options=config.get('logs', {})] - Logger configuration options.
+ * These can override or extend the defaults from the app config.
+ *
+ * @returns {void}
+ *
+ * @example
+ * // Use default config from config.get('logs')
+ * setup();
+ *
+ * @example
+ * // Override default log level
+ * setup({
+ *   level: 'debug',
+ *   console: true
+ * });
+ */
+
 const setup = (options = config.get('logs', {})) => hmpoLogger.config(options);
+
+/**
+ * Retrieves a namespaced logger instance using `hmpo-logger`.
+ *
+ * This is useful for creating scoped loggers tied to specific parts of your app (e.g., modules, features).
+ *
+ * Increases the stack trace level to ensure logs point to the correct source line.
+ *
+ * @param {string} [name=':hmpo-app'] - The name or namespace for the logger (e.g. `':redis'`, `':auth'`). Defaults to `':hmpo-app'`.
+ * @param {number} [level=1] - The stack trace depth offset to apply. This helps ensure logs point to the correct file/line number.
+ *
+ * @returns {Object} A logger instance with methods like `info`, `error`, `warn`, `debug`, etc.
+ *
+ * @example
+ * const log = get(':redis');
+ * log.info('Redis client connected');
+ *
+ * // Default usage
+ * const log = get(); // logs will be under ':hmpo-app'
+ *
+ * // Adjust stack trace depth if wrapping logging logic
+ * const log = get(':custom', 2);
+ */
 
 const get = (name, level = 1) => hmpoLogger.get(name || ':hmpo-app', ++level);
 

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -2,6 +2,51 @@ const redis = require('redis');
 const logger = require('./logger');
 const config = require('./config');
 
+/**
+ * Sets up a Redis client instance, using either a provided connection string or host/port options.
+ *
+ * If a client is already connected, it is closed before creating a new one. The client is stored as a singleton on `redisClient.client`.
+ *
+ * If no connection can be established with a real Redis instance, the function falls back to an in-memory client using `fakeredis`.
+ *
+ * Automatically sets the Redis client name using the app name, hostname, and PM2 process ID (if present).
+ *
+ * @param {Object} [options=config.get('redis', {})] - Configuration options for Redis connection.
+ * @param {string} [options.connectionString] - A full Redis connection URL (e.g. `redis://localhost:6379`).
+ * @param {string} [options.host] - Redis server hostname (used with `port` if no `connectionString` is provided).
+ * @param {number} [options.port=6379] - Redis server port.
+ * @param {Object} [options.socket] - Optional socket-related configuration (e.g. `reconnectStrategy`, `tls`).
+ * @param {string} [options.password] - Redis password for authentication, if required.
+ * @param {boolean} [options.tls] - Whether to enable TLS (can also be configured via `socket` options).
+ * @param {Object} [options.<anyOtherOption>] - Any additional option supported by `redis.createClient()`.
+ *
+ * @returns {import('redis').RedisClientType} A configured and connected Redis client instance.
+ *
+ * @example
+ * // Use default config from the application's config system
+ * const client = redisClient.setup();
+ *
+ * @example
+ * // Provide a connection string explicitly
+ * const client = redisClient.setup({
+ *   connectionString: 'redis://localhost:6379'
+ * });
+ *
+ * @example
+ * // Provide host and port with custom socket options
+ * const client = redisClient.setup({
+ *   host: 'redis.example.com',
+ *   port: 6380,
+ *   socket: {
+ *     reconnectStrategy: retries => Math.min(retries * 50, 2000)
+ *   }
+ * });
+ *
+ * @example
+ * // If Redis is unavailable, setup will fall back to fakeredis
+ * const client = redisClient.setup();
+ * client.set('foo', 'bar'); // Works in-memory
+ */
 const setup = ({
     connectionString,
     host,
@@ -55,8 +100,43 @@ const setup = ({
     return redisClient.client;
 };
 
+/**
+ * Returns the current Redis client instance.
+ *
+ * This will either be:
+ * - a real Redis client created by `redis.createClient()`, or
+ * - an in-memory client from `fakeredis`, if Redis was unavailable during setup.
+ *
+ * @returns The Redis client instance, or `null` if it hasn't been set up yet.
+ *
+ * @example
+ * const client = redisClient.getClient();
+ * if (client) {
+ *   await client.set('key', 'value');
+ * }
+ */
+
 const getClient = () => redisClient.client;
 
+/**
+ * Closes the current Redis client connection, if it is active, and sets the client to `null`.
+ *
+ * If a callback function is provided, it will be called when the Redis client successfully closes the connection.
+ * The client is considered closed if it is disconnected or if the `quit` command has been issued.
+ *
+ * If the Redis client is not connected or hasn't been initialized, the method will simply set the client to `null` and invoke the callback, if provided.
+ *
+ * @param {Function} [cb] - An optional callback function to be invoked once the Redis client has successfully closed.
+ * It will be called with no arguments.
+ *
+ * @returns {void}
+ *
+ * @example
+ * // Close the Redis client and log a message when done
+ * redisClient.close(() => {
+ *   console.log('Redis client closed.');
+ * });
+ */
 const close = (cb) => {
     if (!redisClient.client || !redisClient.client.connected) {
         redisClient.client = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,12 +75,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -208,18 +209,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -235,111 +236,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -349,14 +264,14 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -390,14 +305,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -504,12 +418,25 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
       "dependencies": {
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1583,9 +1510,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1986,9 +1913,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -2010,7 +1937,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -2025,6 +1952,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express-session": {
@@ -3990,9 +3921,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
     "node_modules/pathval": {
@@ -4782,15 +4713,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5155,12 +5077,13 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       }
     },
@@ -5259,15 +5182,15 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -5277,103 +5200,33 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/parser": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/traverse": {
@@ -5400,14 +5253,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       }
     },
     "@eslint-community/eslint-utils": {
@@ -5480,12 +5332,24 @@
       "dev": true
     },
     "@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
       "requires": {
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
+      },
+      "dependencies": {
+        "@eslint/core": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+          "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.15"
+          }
+        }
       }
     },
     "@humanwhocodes/module-importer": {
@@ -6289,9 +6153,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -6570,9 +6434,9 @@
       "dev": true
     },
     "express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
@@ -6594,7 +6458,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -8052,9 +7916,9 @@
       }
     },
     "path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true
     },
     "pathval": {
@@ -8641,12 +8505,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {


### PR DESCRIPTION
- Added further code examples to readme with added detail around params, return values etc.
- Added contribution guide
- Added JS Docs to some of the core functions to make it easier to find usage examples etc. when using hmpo-app.
- `npm audit fix` on some vulns.

Example app seems to be up-to-date and has good examples from what I can see. Don't think it has a redis cache example but I believe this is covered well-enough in the code examples that have been added to the README and JS Docs.